### PR TITLE
[개발] 로그인 API 연동

### DIFF
--- a/src/app/(user)/login/LoginForm.tsx
+++ b/src/app/(user)/login/LoginForm.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import Button from '@/components/common/Button';
+import CheckBox from '@/components/common/CheckBox';
+import Input from '@/components/common/Input';
+import { login } from '@/data/actions/user';
+import useUserStore from '@/stores/useUserStore';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useActionState, useEffect } from 'react';
+
+function LoginForm() {
+  const [userState, formAction, isLoading] = useActionState(login, null);
+  const router = useRouter();
+
+  const setUser = useUserStore((state) => state.login);
+
+  useEffect(() => {
+    if (userState?.ok) {
+      setUser({
+        _id: userState.item._id,
+        email: userState.item.email,
+        name: userState.item.name,
+        type: userState.item.type,
+        // image
+        token: {
+          accessToken: userState.item.token?.accessToken || '',
+          refreshToken: userState.item.token?.refreshToken || '',
+        },
+        loginType: 'email',
+      });
+
+      alert('로그인이 완료되었습니다.');
+
+      /* redirect 추가 예정 (우선 router.back으로 이동) */
+      router.back(); // 이전 페이지로 이동
+    } else {
+      if (!userState?.errors && userState?.message) {
+        console.error('로그인 에러');
+      }
+    }
+  }, [userState]);
+
+  return (
+    <>
+      <form action={formAction} className="flex flex-col gap-2 mt-14 mb-4">
+        <fieldset className="contents">
+          <legend className="sr-only">로그인</legend>
+
+          <Input id="email" label="아이디" placeholder="ID" hideLabel={true} autoComplete="username" />
+          <Input
+            id="password"
+            label="비밀번호"
+            type="password"
+            placeholder="PASSWORD"
+            hideLabel={true}
+            autoComplete="current-password"
+          />
+
+          <div className="flex justify-between mt-4 mb-11">
+            <CheckBox id="rememberUserId" name="rememberUserId" label="아이디 저장" fontSize="sm" />
+            <p className="text-sm">
+              <Link href="#">아이디 찾기</Link> | <Link href="#">비밀번호 찾기</Link>
+            </p>
+          </div>
+        </fieldset>
+        <Button type="submit" shape="square" size="lg">
+          로그인
+        </Button>
+      </form>
+    </>
+  );
+}
+
+export default LoginForm;

--- a/src/app/(user)/login/page.tsx
+++ b/src/app/(user)/login/page.tsx
@@ -1,10 +1,7 @@
-import Button from '@/components/common/Button';
-import CheckBox from '@/components/common/CheckBox';
-import Input from '@/components/common/Input';
+import LoginForm from '@/app/(user)/login/LoginForm';
 import LinkButton from '@/components/common/LinkButton';
 import { Metadata } from 'next';
 import { Judson } from 'next/font/google';
-import Link from 'next/link';
 
 const JudsonFont = Judson({
   subsets: ['latin'],
@@ -26,31 +23,7 @@ function Login() {
       <main className="mx-4">
         <h2 className={`mt-5 text-2xl text-center ${JudsonFont.className}`}>LOGIN</h2>
         <div className="px-4">
-          <form action="" className="flex flex-col gap-2 mt-14 mb-4">
-            <fieldset className="contents">
-              <legend className="sr-only">로그인</legend>
-
-              <Input id="userId" label="아이디" placeholder="ID" hideLabel={true} autoComplete="username" />
-              <Input
-                id="userPassword"
-                label="비밀번호"
-                type="password"
-                placeholder="PASSWORD"
-                hideLabel={true}
-                autoComplete="current-password"
-              />
-
-              <div className="flex justify-between mt-4 mb-11">
-                <CheckBox id="rememberUserId" name="rememberUserId" label="아이디 저장" fontSize="sm" />
-                <p className="text-sm">
-                  <Link href="#">아이디 찾기</Link> | <Link href="#">비밀번호 찾기</Link>
-                </p>
-              </div>
-            </fieldset>
-            <Button type="submit" shape="square" size="lg">
-              로그인
-            </Button>
-          </form>
+          <LoginForm />
 
           <LinkButton href="/signup/terms" shape="square" size="lg" bg="secondary">
             회원가입

--- a/src/app/my-page/MypageMain.tsx
+++ b/src/app/my-page/MypageMain.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import Button from '@/components/common/Button';
+import { Judson } from 'next/font/google';
+import { ChevronRight } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+import useUserStore from '@/stores/useUserStore';
+import { useRouter } from 'next/navigation';
+
+const JudsonFont = Judson({
+  subsets: ['latin'],
+  weight: '700',
+});
+
+function MypageMain() {
+  const router = useRouter();
+  const user = useUserStore((state) => state.user);
+  const logout = useUserStore((state) => state.logout);
+  console.log(user);
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 mb-20">
+        <div className="flex flex-row gap-4 items-center">
+          <Image
+            src="/images/model/main-model2.png"
+            width={44}
+            height={44}
+            alt="프로필 이미지"
+            className="aspect-square rounded-full object-cover"
+          />
+          <span>{user?.name} 님</span>
+        </div>
+        <div className="flex justify-between items-center p-5 rounded-lg border-[.0625rem] border-gray-150 text-sm">
+          <div className="flex flex-col gap-1 items-center">
+            <span className="text-lg">0</span>
+            <span>입금 전</span>
+          </div>
+          <ChevronRight color={'#B0B0B0'} />
+          <div className="flex flex-col gap-1 items-center">
+            <span className="text-lg">0</span>
+            <span>준비 중</span>
+          </div>
+          <ChevronRight color={'#B0B0B0'} />
+          <div className="flex flex-col gap-1 items-center">
+            <span className="text-lg">1</span>
+            <span>배송 중</span>
+          </div>
+          <ChevronRight color={'#B0B0B0'} />
+          <div className="flex flex-col gap-1 items-center">
+            <span className="text-lg">0</span>
+            <span>배송 완료</span>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4">
+          <div>
+            <h2 className={`text-2xl ${JudsonFont.className}`}>Shopping</h2>
+            <ul className="my-1 border-y-[.0625rem] border-gray-350">
+              <li>
+                <Link href="/my-page/order-list" className="block p-4 border-b-[.0625rem] border-gray-150">
+                  주문 내역
+                </Link>
+              </li>
+              <li>
+                <Link href="/my-page/review" className="block p-4">
+                  내가 쓴 리뷰
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className={`text-2xl ${JudsonFont.className}`}>Account</h2>
+            <ul className="my-1 border-y-[.0625rem] border-gray-350">
+              <li>
+                <Link href="/my-page/edit-profile/verify" className="block p-4">
+                  개인 정보 수정
+                </Link>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h2 className={`text-2xl ${JudsonFont.className}`}>Support</h2>
+            <ul className="my-1 border-y-[.0625rem] border-gray-350">
+              <li>
+                <Link href="/my-page/qna" className="block p-4 border-b-[.0625rem] border-gray-150">
+                  1:1 문의
+                </Link>
+              </li>
+              <li>
+                <Link href="/community/notice" className="block p-4">
+                  FAQ
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <Button
+          lang="eng"
+          onClick={() => {
+            logout();
+            router.replace('/login');
+          }}
+        >
+          LOGOUT
+        </Button>
+      </div>
+    </>
+  );
+}
+
+export default MypageMain;

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,14 +1,6 @@
-import Button from '@/components/common/Button';
-import { ChevronRight } from 'lucide-react';
-import { Metadata } from 'next';
-import { Judson } from 'next/font/google';
-import Image from 'next/image';
-import Link from 'next/link';
+import MypageMain from '@/app/my-page/MypageMain';
 
-const JudsonFont = Judson({
-  subsets: ['latin'],
-  weight: '700',
-});
+import { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: '마이페이지 - Twogether',
@@ -23,84 +15,7 @@ function MyPage() {
   return (
     <>
       <main className="mx-4">
-        <div className="flex flex-col gap-4 mb-20">
-          <div className="flex flex-row gap-4 items-center">
-            <Image
-              src="/images/model/main-model2.png"
-              width={44}
-              height={44}
-              alt="프로필 이미지"
-              className="aspect-square rounded-full object-cover"
-            />
-            <p>
-              <span>김멋사</span> 님
-            </p>
-          </div>
-          <div className="flex justify-between items-center p-5 rounded-lg border-[.0625rem] border-gray-150 text-sm">
-            <div className="flex flex-col gap-1 items-center">
-              <span className="text-lg">0</span>
-              <span>입금 전</span>
-            </div>
-            <ChevronRight color={'#B0B0B0'} />
-            <div className="flex flex-col gap-1 items-center">
-              <span className="text-lg">0</span>
-              <span>준비 중</span>
-            </div>
-            <ChevronRight color={'#B0B0B0'} />
-            <div className="flex flex-col gap-1 items-center">
-              <span className="text-lg">1</span>
-              <span>배송 중</span>
-            </div>
-            <ChevronRight color={'#B0B0B0'} />
-            <div className="flex flex-col gap-1 items-center">
-              <span className="text-lg">0</span>
-              <span>배송 완료</span>
-            </div>
-          </div>
-          <div className="flex flex-col gap-4">
-            <div>
-              <h2 className={`text-2xl ${JudsonFont.className}`}>Shopping</h2>
-              <ul className="my-1 border-y-[.0625rem] border-gray-350">
-                <li>
-                  <Link href="/my-page/order-list" className="block p-4 border-b-[.0625rem] border-gray-150">
-                    주문 내역
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/my-page/review" className="block p-4">
-                    내가 쓴 리뷰
-                  </Link>
-                </li>
-              </ul>
-            </div>
-            <div>
-              <h2 className={`text-2xl ${JudsonFont.className}`}>Account</h2>
-              <ul className="my-1 border-y-[.0625rem] border-gray-350">
-                <li>
-                  <Link href="/my-page/edit-profile/verify" className="block p-4">
-                    개인 정보 수정
-                  </Link>
-                </li>
-              </ul>
-            </div>
-            <div>
-              <h2 className={`text-2xl ${JudsonFont.className}`}>Support</h2>
-              <ul className="my-1 border-y-[.0625rem] border-gray-350">
-                <li>
-                  <Link href="/my-page/qna" className="block p-4 border-b-[.0625rem] border-gray-150">
-                    1:1 문의
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/community/notice" className="block p-4">
-                    FAQ
-                  </Link>
-                </li>
-              </ul>
-            </div>
-          </div>
-          <Button lang="eng">LOGOUT</Button>
-        </div>
+        <MypageMain />
       </main>
     </>
   );

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -1,7 +1,12 @@
+'use client';
+
+import useUserStore from '@/stores/useUserStore';
 import { Heart, House, Menu, Search, User } from 'lucide-react';
 import Link from 'next/link';
 
 function Navigation() {
+  const user = useUserStore((state) => state.user);
+
   return (
     <nav className="fixed bottom-0 w-full min-w-[400px] max-w-[768px] bg-white z-[1]">
       <ul className="flex justify-between h-20">
@@ -22,7 +27,10 @@ function Navigation() {
             <Heart size={20} />
             {/* <span>찜</span> */}
           </Link>
-          <Link href="/my-page" className="flex flex-col justify-center items-center content-center flex-1 h-full">
+          <Link
+            href={user ? '/my-page' : '/login'}
+            className="flex flex-col justify-center items-center content-center flex-1 h-full"
+          >
             <User size={20} />
             {/* <span>마이페이지</span> */}
           </Link>

--- a/src/data/actions/user.ts
+++ b/src/data/actions/user.ts
@@ -1,0 +1,28 @@
+import { ApiRes, ApiResPromise, User } from '@/types';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+const CLIENT_ID = process.env.NEXT_PUBLIC_CLIENT_ID || '';
+
+export async function login(state: ApiRes<User> | null, formData: FormData): ApiResPromise<User> {
+  const body = Object.fromEntries(formData.entries());
+
+  let res: Response;
+  let data: ApiRes<User>;
+
+  try {
+    res = await fetch(`${API_URL}/users/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Client-Id': CLIENT_ID,
+      },
+      body: JSON.stringify(body),
+    });
+    data = await res.json();
+    console.log('로그인 성공', data);
+  } catch (error) {
+    console.error(error);
+    return { ok: 0, message: '일시적인 네트워크 문제가 발생했습니다.' };
+  }
+  return data;
+}

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,4 +1,6 @@
+import { User } from '@/types';
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 /**
  * 사용자 정보를 나타내는 인터페이스입니다.
@@ -7,11 +9,11 @@ import { create } from 'zustand';
  * @property {string} name - 사용자 이름
  * @property {string} email - 사용자 이메일
  */
-interface UserInfo {
-  id: string;
-  name: string;
-  email: string;
-}
+// interface UserInfo {
+//   id: string;
+//   name: string;
+//   email: string;
+// }
 
 /**
  * 사용자 상태를 관리하는 Zustand 스토어입니다.
@@ -22,9 +24,9 @@ interface UserInfo {
  * @property {() => void} logout - 로그아웃(사용자 등록 해제) 함수
  */
 interface UserStore {
-  user: UserInfo | null;
+  user: User | null; // 확인 UserInfo -> User
   isLoggedIn: boolean;
-  login(user: UserInfo): void;
+  login(user: User): void;
   logout(): void;
 }
 
@@ -32,19 +34,26 @@ interface UserStore {
  * 사용자의 로그인 상태를 관리하는 Zustand 스토어입니다.
  * @returns {UserStore} 사용자 전역 상태 훅
  */
-const useUserStore = create<UserStore>((set, get) => ({
-  // 상태값 초기화
-  user: null,
-  isLoggedIn: false,
+const useUserStore = create(
+  persist<UserStore>(
+    (set, get) => ({
+      // 상태값 초기화
+      user: null,
+      isLoggedIn: false,
 
-  // 상태 변경 함수
-  login: (user) => {
-    set({ user, isLoggedIn: true });
-  },
+      // 상태 변경 함수
+      login: (user) => {
+        set({ user, isLoggedIn: true });
+      },
 
-  logout: () => {
-    set({ user: null, isLoggedIn: false });
-  },
-}));
+      logout: () => {
+        set({ user: null, isLoggedIn: false });
+      },
+    }),
+    {
+      name: 'user', // 스토리지에 저장될 key 이름
+    }
+  )
+);
 
 export default useUserStore;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,26 @@
+export interface ServerValidationError {
+  type: string;
+  value: string;
+  msg: string;
+  location: string;
+}
+
+/**
+ * Record<K, T>: K(key)로 이루어진 객체의 타입을 T로 지정하는 유틸리티 타입
+ * Partial<T>: T의 모든 속성을 옵셔널로 지정하는 유틸리티 타입
+ * E: 검증에 사용될 속성값을 가지고 있는 타입
+ * 예) 검증에 사용될 속성값을 가지고 있는 타입이 { title: string, content: string }이면,
+ * keyof E의 타입은 'title' | 'content'
+ */
+export type ServerValidationErrors<E> = Partial<Record<keyof E, ServerValidationError>>;
+
+/**
+ * API 서버의 응답
+ * E = never: E가 생략되면 errors 속성도 없음
+ */
+export type ApiRes<T, E = never> = { ok: 1; item: T } | { ok: 0; message: string; errors?: ServerValidationErrors<E> };
+
+/**
+ * 서버 함수에서 반환할 타입(Promise를 반환해야 함)
+ */
+export type ApiResPromise<T> = Promise<ApiRes<T>>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './api';
+export * from './user';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,16 @@
+export interface User {
+  _id: number;
+  email: string;
+  name: string;
+  phone?: string;
+  address?: string;
+  type: 'user';
+  loginType: 'email';
+  image?: string;
+  token?: {
+    accessToken: string;
+    refreshToken: string;
+  };
+  createdAt?: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
## PR 유형

- [x] ✨ feat: 새로운 기능 추가 / 기존 기능의 주요 변경


## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- 로그인 API를 연동했습니다.
- 로그인 성공 시 zustand에 사용자 정보를 저장하도록 구현했습니다.
- 로그인 후 이전 페이지로 이동 처리했습니다. (추후에 redirect 정보를 받아 이동하도록 수정할 예정입니다.)
- `const user = useUserStore((state) => state.user);` 구독한 후 user 사용하면 됩니다.

## 이슈

resolves #55
